### PR TITLE
Adding support for twigcs so it gets automatically downloaded.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "phpcompatibility/php-compatibility": "^9.0",
         "phpmd/phpmd": "^2.8",
         "phpro/grumphp-shim": "^0.19.0",
-        "sebastian/phpcpd": "^3.0 || ^4.0"
+        "sebastian/phpcpd": "^3.0 || ^4.0",
+        "friendsoftwig/twigcs": "^3.2"
     },
     "require-dev": {
         "composer/composer": "^1.0"


### PR DESCRIPTION
Currently in default grumphp.yml.dist has validation rule for the twigcs, so it creates confusion if someone adds the rule but twigcs don't gets downloaded.