### PR TITLE
Explicitly set twigcs ruleset

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -12,6 +12,7 @@ grumphp:
     jsonlint: ~
     twigcs:
       path: 'web'
+      ruleset: 'FriendsOfTwig\Twigcs\Ruleset\Official'
       exclude:
         - core
         - modules/contrib


### PR DESCRIPTION
On some projects Because of the missing ruleset, Grump is failing as it looks for a different ruleset by default which isn't present.