### PR TITLE
Modify readme file to change syntax for copying all dist files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then, copy all the `*.dist` from the library to your project root. The files cop
 * phpmd.xml.dist
 
 ```bash
-cp vendor/axelerant/drupal-quality-checker/*.yml.dist .
+cp vendor/axelerant/drupal-quality-checker/*.dist .
 ```
 
 ## Usage


### PR DESCRIPTION
Modify readme file to change the syntax of copying all dist files [XML, yml] to the root directory of the project 