### PR TITLE
Exclude "\Drupal\Component\Plugin\Factory\DefaultFactory" static access

### DIFF
--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -26,6 +26,7 @@
           \DateTime,
           \DateInterval,
           \DateTimeZone,
+          \Drupal\Component\Plugin\Factory\DefaultFactory,
           \Drupal\Component\Utility\Html,
           \Drupal\Component\Utility\UrlHelper,
           \Drupal\Core\Access\AccessResult,


### PR DESCRIPTION
I purpose to exclude this static access to skip PHPMD warning when create custom plugin manager.