### PR TITLE
Exclude "\Drupal\Core\Render\Element\Checkboxes" class of PHPMD StaticAccess rule

### DIFF
--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -33,9 +33,9 @@
           \Drupal\Core\Url,
           \Drupal\Core\Cache\Cache,
           \Drupal\Core\Render\Element,
+          \Drupal\Core\Render\Element\Checkboxes,
           \Drupal\Core\Annotation\Action,
           \Drupal\Core\Site\Settings,
-          \Drupal\Core\Render\Element\Checkboxes,
         </value>
       </property>
     </properties>


### PR DESCRIPTION
Exclude "\Drupal\Core\Render\Element\Checkboxes" static access