### PR TITLE
phpmd changes

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -45,5 +45,10 @@ grumphp:
     phpmd:
       whitelist_patterns:
         - /^web\/modules\/custom\/(.*)/
-      ruleset: ['phpmd.xml.dist']
-      triggered_by: ['php']
+        - /^web\/themes\/custom\/(.*)/
+      ruleset:
+        - phpmd.xml.dist
+      triggered_by:
+        - php
+        - module
+        - theme

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -9,7 +9,6 @@
   </description>
 
   <!-- Import common rulesets -->
-  <rule ref="rulesets/codesize.xml"/>
   <rule ref="rulesets/design.xml"/>
   <rule ref="rulesets/naming.xml"/>
   <rule ref="rulesets/unusedcode.xml">

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -12,7 +12,9 @@
   <rule ref="rulesets/codesize.xml"/>
   <rule ref="rulesets/design.xml"/>
   <rule ref="rulesets/naming.xml"/>
-  <rule ref="rulesets/unusedcode.xml"/>
+  <rule ref="rulesets/unusedcode.xml">
+    <exclude name="UnusedFormalParameter"/>
+  </rule>
 
   <!-- Import entire clean code rule set, modify StaticAccess rule -->
   <rule ref="rulesets/cleancode.xml">

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -21,29 +21,4 @@
     <exclude name="StaticAccess"/>
     <exclude name="MissingImport"/>
   </rule>
-  <rule ref="rulesets/cleancode.xml/StaticAccess">
-    <properties>
-      <property name="exceptions">
-        <value>
-          \DateTime,
-          \DateInterval,
-          \DateTimeZone,
-          \Drupal\Component\Plugin\Factory\DefaultFactory,
-          \Drupal\Component\Utility\Html,
-          \Drupal\Component\Utility\UrlHelper,
-          \Drupal\Core\Access\AccessResult,
-          \Drupal\Core\Url,
-          \Drupal\Core\Cache\Cache,
-          \Drupal\Core\Render\Element,
-          \Drupal\Core\Render\Element\Checkboxes,
-          \Drupal\Core\Annotation\Action,
-          \Drupal\Core\Site\Settings,
-          \Drupal,
-          \Drupal\Core\Link,
-          \Drupal\Component\Serialization\Json,
-          \Drupal\Core\Entity\Element\EntityAutocomplete,
-        </value>
-      </property>
-    </properties>
-  </rule>
 </ruleset>

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -36,6 +36,10 @@
           \Drupal\Core\Render\Element\Checkboxes,
           \Drupal\Core\Annotation\Action,
           \Drupal\Core\Site\Settings,
+          \Drupal,
+          \Drupal\Core\Link,
+          \Drupal\Component\Serialization\Json,
+          \Drupal\Core\Entity\Element\EntityAutocomplete,
         </value>
       </property>
     </properties>


### PR DESCRIPTION
Below are the changes

1. Whitelist the themes/custom directory for checking.
2. Check for both theme and module extensions as well.
3. Exclude the UnusedFormalParameter rule.
4. Remove the codesize.xml ruleset for now.
5. Completely exclude the StaticAccess ruleset instead of whitelisting static classes, as the list will keep growing.