### PR TITLE
fix: make phpmd more permissive

### DIFF
--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -9,8 +9,27 @@
   </description>
 
   <!-- Import common rulesets -->
-  <rule ref="rulesets/design.xml"/>
-  <rule ref="rulesets/naming.xml"/>
+  <rule ref="rulesets/design.xml">
+    <exclude name="CouplingBetweenObjects"/>
+  </rule>
+
+  <rule ref="rulesets/naming.xml">
+    <exclude name="ShortVariable"/>
+    <exclude name="LongVariable"/>
+  </rule>
+
+  <rule ref="rulesets/naming.xml/ShortVariable">
+    <properties>
+        <property name="exceptions" value="id,op"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/naming.xml/LongVariable">
+    <properties>
+        <property name="maximum" value="30"/>
+    </properties>
+  </rule>
+
   <rule ref="rulesets/unusedcode.xml">
     <exclude name="UnusedFormalParameter"/>
   </rule>


### PR DESCRIPTION
1. Excluded the `CouplingBetweenObjects` rule due to potential errors when utilizing multiple dependency injections.
2. Added exceptions for $id and $op variable names since the default minimum length for short variable names is 3.
3. Increased the maximum variable length to 30 characters, as the default is 20. This adjustment accommodates longer, more descriptive variable names, enhancing code readability.