### PR TITLE
fix: remove trailing slashes to fix regex

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -37,10 +37,10 @@ grumphp:
         - .github
         - .gitlab
         - .ddev
-        - /config/
-        - /drush/
+        - /config
+        - /drush
         - /web/robots.txt
-        - /web/sites/default/
+        - /web/sites/default
         - bower_components
         - node_modules
         - /vendor
@@ -71,10 +71,10 @@ grumphp:
         - .github
         - .gitlab
         - .ddev
-        - /config/
-        - /drush/
+        - /config
+        - /drush
         - /web/robots.txt
-        - /web/sites/default/
+        - /web/sites/default
         - bower_components
         - node_modules
         - /vendor


### PR DESCRIPTION
Removed `/` at end from paths for ignore_patterns in grumphp.yml.dist