### PR TITLE
Remove Unnecessary or Git-Ignored Patterns

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -40,7 +40,7 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /web/robots.txt
-        - /web/sites/default
+        - /^web\/sites\/default/
         - bower_components
         - node_modules
         - /vendor
@@ -74,7 +74,7 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /web/robots.txt
-        - /web/sites/default
+        - /^web\/sites\/default/
         - bower_components
         - node_modules
         - /vendor

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -8,7 +8,12 @@ grumphp:
   tasks:
     phplint:
       exclude:
+        - web/core
+        - web/modules/contrib
+        - web/themes/contrib
+        - web/profiles/contrib
         - web/sites/default
+        - vendor
       triggered_by:
         - php
         - module

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -63,7 +63,6 @@ grumphp:
         - /\.ddev
         - /^config\/(.*)/
         - /drush
-        - /web/robots.txt
         - /^web\/sites\/default/
         - bower_components
         - node_modules

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -34,9 +34,9 @@ grumphp:
       standard:
         - phpcs.xml.dist
       ignore_patterns:
-        - .github
-        - .gitlab
-        - .ddev
+        - /\.github
+        - /\.gitlab
+        - /\.ddev
         - /config
         - /drush
         - /web/robots.txt
@@ -68,9 +68,9 @@ grumphp:
     phpstan:
       configuration: phpstan.neon.dist
       ignore_patterns:
-        - .github
-        - .gitlab
-        - .ddev
+        - /\.github
+        - /\.gitlab
+        - /\.ddev
         - /config
         - /drush
         - /web/robots.txt

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -34,7 +34,6 @@ grumphp:
         - /\.ddev
         - /^config\/(.*)/
         - /drush
-        - /web/robots.txt
         - /^web\/sites\/default/
         - bower_components
         - node_modules
@@ -49,7 +48,6 @@ grumphp:
         - theme
         - css
         - info
-        - txt
     phpmd:
       whitelist_patterns:
         - /^web\/modules\/custom\/(.*)/

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -8,12 +8,7 @@ grumphp:
   tasks:
     phplint:
       exclude:
-        - web/core
-        - web/modules/contrib
-        - web/themes/contrib
-        - web/profiles/contrib
         - web/sites/default
-        - vendor
       triggered_by:
         - php
         - module

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -64,9 +64,6 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /^web\/sites\/default/
-        - bower_components
-        - node_modules
-        - /vendor
       triggered_by:
         - php
         - module

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -35,9 +35,6 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /^web\/sites\/default/
-        - bower_components
-        - node_modules
-        - /vendor
       triggered_by:
         - php
         - module

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -37,7 +37,7 @@ grumphp:
         - /\.github
         - /\.gitlab
         - /\.ddev
-        - /config
+        - /^config\/(.*)/
         - /drush
         - /web/robots.txt
         - /web/sites/default
@@ -71,7 +71,7 @@ grumphp:
         - /\.github
         - /\.gitlab
         - /\.ddev
-        - /config
+        - /^config\/(.*)/
         - /drush
         - /web/robots.txt
         - /web/sites/default


### PR DESCRIPTION
GrumPHP automatically excludes Git-ignored directories by default. Therefore, it is safe to remove those directories from the ignore_patterns configuration

Note: Please merge PR #44 first. 